### PR TITLE
Add rule: Do you make the first 5 seconds of your video irresistible?

### DIFF
--- a/categories/marketing-and-video/rules-to-better-youtube.mdx
+++ b/categories/marketing-and-video/rules-to-better-youtube.mdx
@@ -28,6 +28,7 @@ index:
 - rule: public/uploads/rules/browsing-do-you-add-the-youtube-center-extension/rule.mdx
 - rule: public/uploads/rules/add-sections-time-and-links-on-video-description/rule.mdx
 - rule: public/uploads/rules/do-you-have-a-dog-aka-digital-on-screen-graphic-on-your-videos/rule.mdx
+- rule: public/uploads/rules/make-first-5-seconds-appealing/rule.mdx
   
 ---
 

--- a/public/uploads/rules/make-first-5-seconds-appealing/rule.mdx
+++ b/public/uploads/rules/make-first-5-seconds-appealing/rule.mdx
@@ -43,9 +43,9 @@ A powerful intro should:
 > "If the first 5 seconds don't hook the viewer, nothing else matters." — MrBeast
 
 <boxEmbed
-  style="info"
+  style="tips"
   body={<>
-    Watch your video's analytics for early drop-off points. If viewers leave in the first 5 seconds, rework your opening.
+    **Tip:** Watch your video's analytics for early drop-off points. If viewers leave in the first 5 seconds, rework your opening.
   </>}
   figurePrefix="none"
   figure=""

--- a/public/uploads/rules/make-first-5-seconds-appealing/rule.mdx
+++ b/public/uploads/rules/make-first-5-seconds-appealing/rule.mdx
@@ -1,0 +1,52 @@
+---
+type: rule
+title: Do you make the first 5 seconds of your video irresistible?
+seoDescription: Learn how to hook viewers in the first 5 seconds of your video to maximize watch time and avoid drop-offs.
+uri: make-first-5-seconds-appealing
+authors:
+  - title: Tiago Araujo
+    url: https://ssw.com.au/people/tiago-araujo
+guid: 79347362-5660-48e2-a531-10c79b2ea631
+created: 2026-04-27T00:00:00.000Z
+categories:
+  - category: categories/marketing-and-video/rules-to-better-youtube.mdx
+---
+
+Most viewers decide in the first 5 seconds whether to keep watching or scroll past. Nail the opening and they stay. Miss it and they are gone.
+
+<endIntro />
+
+A powerful intro should:
+
+* **Match the title and thumbnail:** Deliver on the promise of your content. If viewers feel misled, they leave
+* **Grab attention:** Remove all dull moments and get straight to the point. No long intros, no slow builds
+* **Build curiosity:** Tease what is coming next to give viewers a reason to stay
+
+<boxEmbed
+  style="greybox"
+  body={<>
+    "Hey guys, welcome back to my channel! Today I'm going to be talking about..."
+  </>}
+  figurePrefix="bad"
+  figure="Generic greetings waste precious seconds and lose viewers before the content even starts"
+/>
+
+<boxEmbed
+  style="greybox"
+  body={<>
+    "I just found the fastest way to edit videos and it cuts production time in half. Here's how..."
+  </>}
+  figurePrefix="good"
+  figure="Leads with the value, sparks curiosity, and sets up what is coming"
+/>
+
+> "If the first 5 seconds don't hook the viewer, nothing else matters." — MrBeast
+
+<boxEmbed
+  style="info"
+  body={<>
+    Watch your video's analytics for early drop-off points. If viewers leave in the first 5 seconds, rework your opening.
+  </>}
+  figurePrefix="none"
+  figure=""
+/>


### PR DESCRIPTION
## Summary

- Adds new rule on making the first 5 seconds of a video compelling to keep viewers watching
- Covers three key principles: matching title/thumbnail, grabbing attention, and building curiosity
- Includes good/bad examples using `<boxEmbed>` components
- Adds the rule to the **Rules to Better YouTube** category

## Changes

- `public/uploads/rules/make-first-5-seconds-appealing/rule.mdx` — new rule
- `categories/marketing-and-video/rules-to-better-youtube.mdx` — rule added to index

## Test plan

- [ ] Rule renders correctly on the SSW Rules site
- [ ] Good/bad `<boxEmbed>` boxes display as expected
- [ ] Rule appears in the YouTube category listing

🤖 Generated with [Claude Code](https://claude.com/claude-code)